### PR TITLE
Updated the DynamoS3 Default Test Database Table names to have a common prefix.

### DIFF
--- a/src/test/java/cloud/orbit/actors/extensions/dynamos3/test/BaseDynamoDBS3PersistenceTest.java
+++ b/src/test/java/cloud/orbit/actors/extensions/dynamos3/test/BaseDynamoDBS3PersistenceTest.java
@@ -70,7 +70,7 @@ import static org.junit.Assert.*;
 
 public abstract class BaseDynamoDBS3PersistenceTest extends StorageBaseTest
 {
-    protected static final String DEFAULT_TABLE_NAME = "orbit-test";
+    protected static final String DEFAULT_TABLE_NAME = "orbit-ci-test";
     protected static final String TEST_STRING_LONG = new String(new char[3000000]).replace("\0", "X");
 
     private DynamoDBConnection dynamoDBConnection;

--- a/src/test/java/cloud/orbit/actors/extensions/dynamos3/test/HelloStateWithIdOverrideAndCollection.java
+++ b/src/test/java/cloud/orbit/actors/extensions/dynamos3/test/HelloStateWithIdOverrideAndCollection.java
@@ -30,7 +30,7 @@ package cloud.orbit.actors.extensions.dynamos3.test;
 
 import cloud.orbit.actors.extensions.dynamodb.DynamoDBStateConfiguration;
 
-@DynamoDBStateConfiguration(collection = "helloIdAndCollection", idDecorationOverride = "3W2rQqmuuYPKznDYNNn3GB")
+@DynamoDBStateConfiguration(collection = "orbit-ci-test-helloIdAndCollection", idDecorationOverride = "3W2rQqmuuYPKznDYNNn3GB")
 public class HelloStateWithIdOverrideAndCollection extends HelloState
 {
 }


### PR DESCRIPTION
This allows tests/user permissions to be more easily configured with a wildcard on table names
